### PR TITLE
feat: Migrate Etherscan API v2

### DIFF
--- a/apps/server/src/_scripts/config.ts
+++ b/apps/server/src/_scripts/config.ts
@@ -1,10 +1,16 @@
 import { alchemy } from 'chainsmith/src';
 import * as Adapters from 'chainsmith/src/adapters';
-import { ALCHEMY_API_KEY, CMC_API_BASE_URL, CMC_API_KEY } from '../constants';
+import {
+  ALCHEMY_API_KEY,
+  CMC_API_BASE_URL,
+  CMC_API_KEY,
+  ETHERSCAN_API_KEY,
+  ETHERSCAN_BASE_URL,
+} from '../constants';
 
 export const AdapterRegistry = {
   CoinMarketcap: new Adapters.CoinMarketcapAdapter(CMC_API_BASE_URL, CMC_API_KEY),
   Uniswap: new Adapters.UniswapSdkAdapter(alchemy(ALCHEMY_API_KEY)),
-  Evmscan: new Adapters.EvmscanAdapter(CMC_API_BASE_URL, CMC_API_KEY),
+  Evmscan: new Adapters.EvmscanAdapter(ETHERSCAN_BASE_URL, ETHERSCAN_API_KEY),
   DexScreener: new Adapters.DexScreenerAdapter(),
 };

--- a/apps/server/src/_scripts/index.ts
+++ b/apps/server/src/_scripts/index.ts
@@ -13,7 +13,7 @@ function testExternalities(enabled: boolean, f: () => Promise<any>) {
 
 async function fetchMultichainPortfolioWorks() {
   const wallets = {};
-  for (const wallet of [Wallets.ETH_MAINNET_WALLET_PCMINH, Wallets.ETH_MAINNET_WALLET_JESSE]) {
+  for (const wallet of [Wallets.ETH_MAINNET_WALLET_PCMINH]) {
     wallets[wallet] = await sdk.portfolio.getMultichainTokenPortfolio(
       AdapterRegistry.CoinMarketcap
     )(wallet);
@@ -23,15 +23,18 @@ async function fetchMultichainPortfolioWorks() {
 
 async function fetchEvmscanTokenActivitiesWorks() {
   sdk.storage.writeToRam('walletAddress', Wallets.ETH_MAINNET_WALLET_PCMINH);
-  return sdk.token.listTokenTransferActivities(AdapterRegistry.Evmscan)();
+  const tokenTransferActivities = await sdk.token.listTokenTransferActivities(
+    AdapterRegistry.Evmscan
+  )();
+  return tokenTransferActivities;
 }
 
 async function fetchDexScreenerParis() {
   return AdapterRegistry.DexScreener.fetchDexScreenerData(
-    'A55XjvzRU4KtR3Lrys8PpLZQvPojPqvnv5bJVHMYy3Jv'
+    '0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842'
   );
 }
 
 testExternalities(false, fetchMultichainPortfolioWorks);
-testExternalities(false, fetchEvmscanTokenActivitiesWorks);
-testExternalities(true, fetchDexScreenerParis);
+testExternalities(true, fetchEvmscanTokenActivitiesWorks);
+testExternalities(false, fetchDexScreenerParis);

--- a/apps/server/src/constants/env.ts
+++ b/apps/server/src/constants/env.ts
@@ -6,5 +6,5 @@ export const SIMPLE_HASH_API_KEY = process.env.SIMPLE_HASH_API_KEY;
 export const CMC_API_BASE_URL = 'https://pro-api.coinmarketcap.com';
 export const CMC_API_KEY = process.env.CMC_API_KEY || '';
 
-export const ETHERSCAN_BASE_URL = process.env.ETHERSCAN_BASE_URL;
+export const ETHERSCAN_BASE_URL = 'https://api.etherscan.io/v2/api';
 export const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY;

--- a/packages/core/src/adapters/evmscan/index.ts
+++ b/packages/core/src/adapters/evmscan/index.ts
@@ -43,7 +43,7 @@ export class EvmscanAdapter implements IOnchainActivityAdapter {
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const evmScanResp = await this.getTokenActivities('tokentx', address, {
+      const evmScanResp = await this.getTokenActivities('tokentx', address, chain.id, {
         offset,
       });
       const currentResultCount = evmScanResp.result.length;
@@ -73,6 +73,7 @@ export class EvmscanAdapter implements IOnchainActivityAdapter {
   async getTokenActivities(
     action: string,
     address: string,
+    chainId: number,
     queryOptions: Partial<GetTokenActivityQueryOptions> = {
       offset: 0,
       startblock: 0,
@@ -80,14 +81,14 @@ export class EvmscanAdapter implements IOnchainActivityAdapter {
     }
   ): Promise<TEVMScanResponse> {
     const params = objectToQueryString(queryOptions);
-    const query = `module=account&action=${action}&address=${address}&${params}&&apikey=${this.apiKey}`;
+    const query = `chainid=${chainId}&module=account&action=${action}&address=${address}&${params}&apikey=${this.apiKey}`;
     const res = await axios.get(`${this.apiUrl}?${query}`, {
       headers: {
         'Content-Type': 'application/json',
         'User-Agent': 'PostmanRuntime/7.40.0',
       },
     });
-    const result = await res.data.json();
-    return result.data;
+    const result = await res.data;
+    return result;
   }
 }

--- a/packages/core/src/plugins/token/index.ts
+++ b/packages/core/src/plugins/token/index.ts
@@ -55,7 +55,7 @@ export class MultichainTokenPlugin {
       try {
         const chainActivitiesRecord: IMultichain<TTokenTransferActivity[]> = {};
         for (const chain of this.storagePlugin.readDiskOrReturn({ chains })) {
-          chainActivitiesRecord[chain.chainName] = adapter.listAllTokenActivities(
+          chainActivitiesRecord[chain.chainName] = await adapter.listAllTokenActivities(
             chain.chainName,
             this.storagePlugin.readRamOrReturn({ walletAddress }),
             100


### PR DESCRIPTION
**What changed? Why?**
- Support Etherscan V2 (for ERC20 TokenActivities, or many more)

**Notes to reviewers**
- N/A (review code ẩu vãi lìn đi clone CMC cho Etherscan)

**How has it been tested?**
- bun dev:script passed